### PR TITLE
Add build to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM openjdk:8-jdk-alpine
+FROM maven:3.5.2-jdk-8-alpine
 
-COPY target/inventory*.jar /inventory/app.jar
+COPY . /build
+RUN cd /build && mvn clean install && mkdir /inventory && cp /build/target/inventory*.jar /inventory/app.jar
 
 ENTRYPOINT [ "sh", "-c", "java -jar /inventory/app.jar --spring.datasource.url=$DATABASE_URL --spring.datasource.username=$DATABASE_USER --spring.datasource.password=$DATABASE_PASSWORD" ]


### PR DESCRIPTION
This should make possible to build an image without the need to build the src outside the docker.

By merging this, the automated build should be fixed:
https://hub.docker.com/r/robertoduessmann/inventory/builds/